### PR TITLE
Fix bug with clear button on filter popup menu

### DIFF
--- a/ext.headerfilter.js
+++ b/ext.headerfilter.js
@@ -151,10 +151,10 @@
 
             $('<button>Clear</button>')
                 .appendTo($menu)
-                .bind('click', function () {
+                .bind('click', function (ev) {
                     columnDef.filterValues.length = 0;
                     setButtonImage($menuButton, false);
-                    handleApply(e, columnDef);
+                    handleApply(ev, columnDef);
                 });
 
             $('<button>Cancel</button>')


### PR DESCRIPTION
The clear button click handler was passing the event object from the
parent scope instead of the correct one.
