### PR TITLE
Fixed a bug so the popup filter window will open upward if needed

### DIFF
--- a/ext.headerfilter.js
+++ b/ext.headerfilter.js
@@ -168,7 +168,12 @@
             var offset = $(this).offset();
             var left = offset.left - $menu.width() + $(this).width() - 8;
 
-            $menu.css("top", offset.top + $(this).height())
+            var menutop = offset.top + $(this).height();
+
+            if (menutop + offset.top > $(window).height()) {
+                menutop -= ($menu.height() + $(this).height() + 8);
+            }
+            $menu.css("top", menutop)
                  .css("left", (left > 0 ? left : 0));
         }
 


### PR DESCRIPTION
The bug is blatantly apparent if you create the table to be at the bottom of a page. Then the popup filter window will go off the page when opened. My fix allows the popup filter window to open upward if there is not enough room to open downward. The quickest way to see this is take the example-1-everything.htm file and change the line

.excel-grid {
    position: absolute;
    top: 55px;
    left: 0;
    right: 0;
    bottom: 26px;
}

to something that pushes the table near the bottom of the page like

.excel-grid {
    position: absolute;
    top: 500px;
    left: 0;
    right: 0;
    bottom: 26px;
}
