### PR TITLE
Fixed workingFilters scope issue (which broke filtering based on results down-selected by searching).

### DIFF
--- a/ext.headerfilter.js
+++ b/ext.headerfilter.js
@@ -24,6 +24,8 @@
             sortDescImage: "../images/sort-desc.png"
         };
         var $menu;
+        // The currently selected (but not necessarily applied) filters.
+        var workingFilters = [];
 
         function init(g) {
             options = $.extend(true, {}, defaults, options);
@@ -134,7 +136,7 @@
             columnDef.filterValues = columnDef.filterValues || [];
 
             // WorkingFilters is a copy of the filters to enable apply/cancel behaviour
-            var workingFilters = columnDef.filterValues.slice(0);
+            workingFilters = columnDef.filterValues.slice(0);
 
             var filterItems;
 
@@ -211,7 +213,7 @@
             hideMenu();
         }
 
-        function changeWorkingFilter(filterItems, workingFilters, $checkbox) {
+        function changeWorkingFilter(filterItems, baseWorkingFilters, $checkbox) {
             var value = $checkbox.val();
             var $filter = $checkbox.parent().parent();
 
@@ -219,25 +221,25 @@
                 // Select All
                 if ($checkbox.prop('checked')) {
                     $(':checkbox', $filter).prop('checked', true);
-                    workingFilters = filterItems.slice(0);
+                    baseWorkingFilters = filterItems.slice(0);
                 } else {
                     $(':checkbox', $filter).prop('checked', false);
-                    workingFilters.length = 0;
+                    baseWorkingFilters.length = 0;
                 }
             } else {
-                var index = _.indexOf(workingFilters, filterItems[value]);
+                var index = _.indexOf(baseWorkingFilters, filterItems[value]);
 
                 if ($checkbox.prop('checked') && index < 0) {
-                    workingFilters.push(filterItems[value]);
+                    baseWorkingFilters.push(filterItems[value]);
                 }
                 else {
                     if (index > -1) {
-                        workingFilters.splice(index, 1);
+                        baseWorkingFilters.splice(index, 1);
                     }
                 }
             }
 
-            return workingFilters;
+            return baseWorkingFilters;
         }
 
         function setButtonImage($el, filtered) {


### PR DESCRIPTION
workingFilters was defined in the scope of 'showFilter', but used outside that scope. It mostly worked, except when searching and then selecting filters. In that case, the workingFilters was set as an implicitly defined global, and the changes weren't picked up when 'OK' is clicked. 
 - Moved the definition of workingFilters to the HeaderFilter() scope, which contains all the functions that use it.
 - Renamed workingFilters in the changeWorkingFilter function to baseWorkingFilter, to make it clear that we're working with a locally passed argument instead of the higher scoped workingFilters.